### PR TITLE
Update loadConfigs.ts

### DIFF
--- a/packages/appwrite-utils-cli/src/utils/loadConfigs.ts
+++ b/packages/appwrite-utils-cli/src/utils/loadConfigs.ts
@@ -52,7 +52,9 @@ export const loadConfig = async (
       config.collections.push(collectionModule);
     }
 
-    return config;
+    // to fix the issue of undefined databases etc, due to code looking for 
+    // e.g. this.config.appwriteEndpoint but receiving this.config.default.appwrite.endpoint 
+    return config.default;
   } finally {
     unregister(); // Unregister tsx when done
   }


### PR DESCRIPTION
Load config returns an boject config with a key default containing the configuration object This causes an error in utilsController as it expects a config object exposing all the other keys (eg appwriteEndpoint) directly instead of as default subkeys